### PR TITLE
things n stuff

### DIFF
--- a/acnh_mate_frontend/lib/Widgets/scaffold_widget.dart
+++ b/acnh_mate_frontend/lib/Widgets/scaffold_widget.dart
@@ -25,13 +25,22 @@ class _ScaffoldWidgetState extends State<ScaffoldWidget> {
           ListTile(
             selectedTileColor: Colors.blue,
             title: const Text('Home'),
-            onTap: () => Navigator.pushNamed(context, "/home"),
+            onTap: (){
+              var pageName = "/home";
+              Navigator.pushNamed(context, pageName);
+            },
           ),
           ListTile(
               selectedTileColor: Colors.blue,
               title: const Text('Collections'),
-              onTap: () => Navigator.pushNamed(context, "/collections")),
+              onTap: (){
+                var pageName = "/collections";
+                Navigator.pushNamed(context, pageName);
+              }),
         ])),
         body: widget.body);
   }
+
+
+
 }

--- a/acnh_mate_frontend/lib/main.dart
+++ b/acnh_mate_frontend/lib/main.dart
@@ -12,19 +12,24 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    Map routes = {
+      "/home": (context) => const HomePage(),
+      "/collections": (context) => const CollectionPage(),
+    };
+
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-
-        primarySwatch: Colors.blue,
-      ),
-      home: const HomePage(),
-
-      routes: {
-        "/home": (context) => HomePage(),
-        "/collections": (context) => CollectionPage(),
-      }
-    );
-
+        title: 'Flutter Demo',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: const HomePage(),
+        initialRoute: "/home",
+        onGenerateRoute: (settings) {
+          if (ModalRoute.of(context)?.settings.name == settings.name) return null; //Check if already on page
+          return PageRouteBuilder(
+              transitionDuration: Duration.zero,
+              settings: settings,
+              pageBuilder: (_, __, ___) => routes[settings.name](context));
+        });
   }
 }


### PR DESCRIPTION
Use pageroutebuilder to control animations manually, all navigation animations are now off by default (main.dart line 29)
Disable navigating to page thats already active with a check (main.dart line 28)